### PR TITLE
Fix compatibility with TOML 0.9.x

### DIFF
--- a/src/dip.rs
+++ b/src/dip.rs
@@ -9,8 +9,7 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
-use toml::map::Map;
-use toml::Value;
+use toml::Table;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, PartialEq)]
@@ -393,11 +392,10 @@ impl fmt::Display for Dip {
 impl FromStr for Dip {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v = match s.parse::<Value>() {
+        let toml = match s.trim().parse::<Table>() {
             Err(err) => return Err(err.to_string()),
             Ok(p) => p,
         };
-        let toml = v.as_table().unwrap();
 
         let name = match toml.get("name") {
             None => return Err("no name".to_string()),
@@ -441,7 +439,7 @@ impl FromStr for Dip {
             },
         };
 
-        match pins_to_vec_result(toml, dip) {
+        match pins_to_vec_result(&toml, dip) {
             Err(err) => Err(err),
             Ok(pins) => Ok(Dip {
                 name,
@@ -455,7 +453,7 @@ impl FromStr for Dip {
 }
 
 fn pins_to_vec_result(
-    toml: &Map<String, Value>,
+    toml: &Table,
     dip: usize,
 ) -> Result<BTreeMap<usize, PinName>, String> {
     let mut pins = BTreeMap::new();
@@ -620,7 +618,7 @@ fn test_decode_error() {
          "#
         )
         .err(),
-        Some("TOML parse error at line 6, column 13\n  |\n6 |             1 = \"pin2\"\n  |             ^\nduplicate key `1` in document root\n".to_string())
+        Some("TOML parse error at line 5, column 13\n  |\n5 |             1 = \"pin2\"\n  |             ^\nduplicate key\n".to_string())
     );
     assert_eq!(
         Dip::from_str(


### PR DESCRIPTION
## Summary

This PR fixes failing tests caused by API changes in the toml crate version 0.9.8.

## Changes Made

- **Updated TOML imports**: Changed from `toml::map::Map` and `toml::Value` to `toml::Table`
- **Modified FromStr implementation**: Parse directly to `Table` type instead of `Value`
- **Added input trimming**: Trim input strings before parsing to handle leading/trailing whitespace
- **Updated function signatures**: Changed `pins_to_vec_result` parameter type to `&Table`
- **Fixed test expectations**: Updated error message assertions to match new TOML library format

## Test Results

All 4 tests now pass:
- ✅ `print::test_print_left_right`
- ✅ `print::test_print_top_bottom`
- ✅ `dip::test_dip_decode`
- ✅ `dip::test_decode_error`

## Technical Details

The TOML 0.9.x API requires parsing TOML documents directly into the `Table` type rather than the `Value` type. The error messages have also been simplified in the newer version, which required updating test expectations.